### PR TITLE
adding pickup button logic through player signalling from pickup itself

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -65,6 +65,12 @@ throw={
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":5,"axis_value":1.0,"script":null)
 ]
 }
+equip={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":69,"key_label":0,"unicode":101,"location":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":2,"pressure":0.0,"pressed":false,"script":null)
+]
+}
 
 [layer_names]
 

--- a/scenes/Weapon/pickup.tscn
+++ b/scenes/Weapon/pickup.tscn
@@ -1,5 +1,6 @@
 [gd_scene format=3 uid="uid://df01s271qlbxd"]
 
+[ext_resource type="Texture2D" uid="uid://phrc88hia5pj" path="res://assets/2d_lights_and_shadows_neutral_point_light.webp" id="1_lu1qc"]
 [ext_resource type="Script" uid="uid://b6u63h087idg0" path="res://scripts/components/pickup.gd" id="2_bn5xs"]
 [ext_resource type="Texture2D" uid="uid://b0cabb0k173rp" path="res://assets/aseprite/boulder.png" id="2_kqu22"]
 [ext_resource type="Script" uid="uid://cbkfrsu3q3345" path="res://scripts/components/damage.gd" id="3_kqu22"]
@@ -17,13 +18,35 @@ height = 125.995125
 [sub_resource type="LabelSettings" id="LabelSettings_kqu22"]
 font_size = 31
 
+[sub_resource type="SceneReplicationConfig" id="SceneReplicationConfig_kqu22"]
+properties/0/path = NodePath(".:position")
+properties/0/spawn = true
+properties/0/replication_mode = 1
+properties/1/path = NodePath(".:linear_velocity")
+properties/1/spawn = true
+properties/1/replication_mode = 1
+properties/2/path = NodePath(".:rotation")
+properties/2/spawn = true
+properties/2/replication_mode = 1
+
 [node name="Pickup" type="RigidBody2D" unique_id=1888499280]
+z_index = 1
 collision_layer = 10
 collision_mask = 10
 mass = 8.166
 physics_material_override = SubResource("PhysicsMaterial_vsyep")
 contact_monitor = true
 max_contacts_reported = 1
+
+[node name="CanEquipLight" type="PointLight2D" parent="." unique_id=422587244]
+unique_name_in_owner = true
+visible = false
+light_mask = 2
+visibility_layer = 2
+position = Vector2(-0.50000167, 0.50000167)
+scale = Vector2(0.41015625, 0.41015625)
+color = Color(0.15686275, 1, 0.9019608, 1)
+texture = ExtResource("1_lu1qc")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="." unique_id=1945410480]
 shape = SubResource("CircleShape2D_lu1qc")
@@ -37,10 +60,12 @@ position = Vector2(0, -1.0000001)
 rotation = -1.5685139
 shape = SubResource("CapsuleShape2D_xasec")
 
-[node name="Pickup" type="Node" parent="." unique_id=36309700 node_paths=PackedStringArray("pickup", "pickup_area")]
+[node name="Pickup" type="Node" parent="." unique_id=36309700 node_paths=PackedStringArray("pickup", "pickup_area", "pickup_light", "cooldown_timer")]
 script = ExtResource("2_bn5xs")
 pickup = NodePath("..")
 pickup_area = NodePath("../PickupArea")
+pickup_light = NodePath("../CanEquipLight")
+cooldown_timer = NodePath("../CooldownTimer")
 metadata/_custom_type_script = "uid://b6u63h087idg0"
 
 [node name="Damage" type="Node" parent="." unique_id=246605701 node_paths=PackedStringArray("pickup_body")]
@@ -50,6 +75,7 @@ damage = 500
 metadata/_custom_type_script = "uid://cbkfrsu3q3345"
 
 [node name="Sprite2D" type="Sprite2D" parent="." unique_id=107015527]
+light_mask = 0
 position = Vector2(-1, -2)
 scale = Vector2(1.2924805, 1.2465705)
 texture = ExtResource("2_kqu22")
@@ -67,6 +93,10 @@ offset_bottom = -42.0
 label_settings = SubResource("LabelSettings_kqu22")
 horizontal_alignment = 1
 
+[node name="MultiplayerSynchronizer" type="MultiplayerSynchronizer" parent="." unique_id=881023540]
+replication_config = SubResource("SceneReplicationConfig_kqu22")
+
 [connection signal="body_entered" from="." to="Damage" method="_on_pickup_body_entered"]
 [connection signal="area_entered" from="PickupArea" to="Pickup" method="_on_pickup_area_area_entered"]
+[connection signal="area_exited" from="PickupArea" to="Pickup" method="_on_pickup_area_area_exited"]
 [connection signal="timeout" from="CooldownTimer" to="Pickup" method="_on_cooldown_timer_timeout"]

--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -27,16 +27,18 @@ position = Vector2(1680.0001, 1875.125)
 scale = Vector2(11.609375, 9.454102)
 shadow_color = Color(0, 0, 0, 0.8784314)
 texture = ExtResource("1_tbgi4")
+metadata/_edit_lock_ = true
 
 [node name="Background" type="Sprite2D" parent="." unique_id=1564463435]
 position = Vector2(1754.4376, 989.37506)
 scale = Vector2(3.5865884, 3.5615742)
 texture = ExtResource("1_jyhfs")
+metadata/_edit_lock_ = true
 
 [node name="Camera2D" type="Camera2D" parent="." unique_id=1240736190]
 position = Vector2(1765, 1004.0001)
 scale = Vector2(0.65, 0.65)
-zoom = Vector2(0.33, 0.33)
+zoom = Vector2(0.335, 0.335)
 
 [node name="CollisionBlocks" type="Node2D" parent="." unique_id=227081774]
 position = Vector2(849, 1274)

--- a/scenes/player.tscn
+++ b/scenes/player.tscn
@@ -8,15 +8,6 @@
 [ext_resource type="Script" uid="uid://5uig6yhhkjxp" path="res://scripts/components/health.gd" id="5_qlg0r"]
 [ext_resource type="Script" uid="uid://b1o88cfk7oxaa" path="res://scripts/canvas_layer.gd" id="6_tuyoq"]
 
-[sub_resource type="LabelSettings" id="LabelSettings_qlg0r"]
-outline_color = Color(0, 0, 0, 1)
-
-[sub_resource type="CircleShape2D" id="CircleShape2D_dqkch"]
-radius = 100.62
-
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_tuyoq"]
-size = Vector2(123, 151)
-
 [sub_resource type="AtlasTexture" id="AtlasTexture_a8ls1"]
 atlas = ExtResource("2_fjrip")
 region = Rect2(128, 0, 64, 64)
@@ -119,6 +110,12 @@ animations = [{
 "name": &"jump",
 "speed": 5.0
 }]
+
+[sub_resource type="LabelSettings" id="LabelSettings_qlg0r"]
+outline_color = Color(0, 0, 0, 1)
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_tuyoq"]
+size = Vector2(123, 151)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_3v2ag"]
 atlas = ExtResource("1_dqkch")
@@ -259,11 +256,17 @@ properties/1/replication_mode = 1
 [sub_resource type="LabelSettings" id="LabelSettings_fjrip"]
 font_size = 33
 
-[node name="Player" type="CharacterBody2D" unique_id=1608990892]
+[node name="Player" type="CharacterBody2D" unique_id=1946755356]
 collision_layer = 5
 collision_mask = 5
 script = ExtResource("1_qlg0r")
+metadata/_custom_type_script = "uid://jb258fphxmv2"
 metadata/current_weapon = NodePath("")
+
+[node name="WizardSprite" type="AnimatedSprite2D" parent="." unique_id=338670132]
+position = Vector2(-3.8146973e-06, 0)
+scale = Vector2(2.1396484, 1.9596782)
+sprite_frames = SubResource("SpriteFrames_a38lo")
 
 [node name="CanvasLayer" type="CanvasLayer" parent="." unique_id=1320438639]
 layer = 2
@@ -355,25 +358,13 @@ rotation = -0.45417586
 scale = Vector2(1.1200004, 0.91055155)
 expand_mode = 1
 
-[node name="PickupTrigger" type="Area2D" parent="." unique_id=843709192]
-collision_layer = 4
-collision_mask = 4
-
-[node name="AnimationDetectionShape" type="CollisionShape2D" parent="PickupTrigger" unique_id=2060057639]
-position = Vector2(-1, -4)
-shape = SubResource("CircleShape2D_dqkch")
-
 [node name="AnimationTriggerArea" type="Area2D" parent="." unique_id=1562431500]
+visible = false
 position = Vector2(-4, -1)
 
 [node name="AnimationDetectionShape" type="CollisionShape2D" parent="AnimationTriggerArea" unique_id=1529214188]
 position = Vector2(1, -1)
 shape = SubResource("RectangleShape2D_tuyoq")
-
-[node name="WizardSprite" type="AnimatedSprite2D" parent="." unique_id=338670132]
-position = Vector2(-3.8146973e-06, 0)
-scale = Vector2(2.1396484, 1.9596782)
-sprite_frames = SubResource("SpriteFrames_a38lo")
 
 [node name="PlayerSprite" type="AnimatedSprite2D" parent="." unique_id=999978471]
 visible = false
@@ -383,6 +374,7 @@ sprite_frames = SubResource("SpriteFrames_3v2ag")
 animation = &"airborne"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="." unique_id=611591813]
+visible = false
 position = Vector2(-4, -1)
 shape = SubResource("RectangleShape2D_64qw0")
 
@@ -391,6 +383,7 @@ position = Vector2(-3, 0)
 script = ExtResource("2_qhqgy")
 
 [node name="Area2D" type="Area2D" parent="Equipment" unique_id=35284940]
+visible = false
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Equipment/Area2D" unique_id=907572108]
 position = Vector2(3, -7)
@@ -400,6 +393,15 @@ shape = SubResource("CircleShape2D_tuyoq")
 unique_name_in_owner = true
 position = Vector2(3, -7.6293945e-06)
 scale = Vector2(1.0000001, 1.0000001)
+
+[node name="PickupTrigger" type="Area2D" parent="Equipment/WeaponMarker" unique_id=843709192]
+position = Vector2(0, 7.6293936e-06)
+scale = Vector2(0.9999999, 0.9999999)
+collision_layer = 4
+collision_mask = 4
+
+[node name="AnimationDetectionShape" type="CollisionPolygon2D" parent="Equipment/WeaponMarker/PickupTrigger" unique_id=1119736113]
+polygon = PackedVector2Array(0, 0, 144, -146, 203, -2)
 
 [node name="Health" type="Node" parent="." unique_id=1476547498]
 script = ExtResource("5_qlg0r")
@@ -422,7 +424,8 @@ offset_bottom = -90.0
 label_settings = SubResource("LabelSettings_fjrip")
 horizontal_alignment = 1
 
+[connection signal="allow_equip" from="." to="." method="_on_allow_equip"]
+[connection signal="done_equipping" from="." to="." method="_on_done_equipping"]
 [connection signal="equip" from="." to="." method="_on_equip"]
 [connection signal="released" from="." to="." method="_on_released"]
-[connection signal="area_entered" from="PickupTrigger" to="." method="_on_pickup_trigger_area_entered"]
 [connection signal="body_entered" from="AnimationTriggerArea" to="." method="_on_animation_trigger_area_body_entered"]

--- a/scripts/components/health.gd
+++ b/scripts/components/health.gd
@@ -10,4 +10,5 @@ func _ready() -> void:
 
 func check_health():
 	if health <= 0 and free_on_death:
+		# FIXME: Server should be responsible for freeing players otherwise it wont sync
 		get_parent().queue_free()

--- a/scripts/components/pickup.gd
+++ b/scripts/components/pickup.gd
@@ -1,39 +1,61 @@
 class_name Pickup extends Node
 
+#TODO: Its worth reconsidering this component structure. Seems like its not actually providing much benefit? 
+# Hard to tell though, will need to make more pickups to see
+
 @export var pickup: RigidBody2D
 @export var pickup_area: Area2D
+@export var pickup_light: PointLight2D
+@export var cooldown_timer: Timer
 @export var weapon_scene_address: String = "res://scenes/Weapon/weapon.tscn"
+
 var weapon_scene: PackedScene = load(weapon_scene_address) # Can't preload this because its called from an export var
-var can_pickup = false
+var pickup_blocked = true
+var player_in_range = false
 
 func _on_pickup_area_area_entered(area: Area2D) -> void:
 	# Only players should trigger pickup logic
-	if area.get_parent() is not Player or not can_pickup:
+	if area.owner.get_script().get_global_name() != "Player" or pickup_blocked:
 		return
 
-	if (area.get_parent() as Player).state.equipped_weapon is Weapon:
-		print("A weapon is already equipped, skipping equip logic")
+	if (area.owner as Player).state.equipped_weapon is Weapon:
 		return
 
-	var player: Player = area.get_parent()
-	print(str(multiplayer.get_unique_id()) + ": Is emitting equip signal")
-	player.equip.emit(weapon_scene)
-	server_despawn.rpc()
+	var player: Player = area.owner
+	player_in_range = true
+	toggle_light.rpc_id(player.get_multiplayer_authority())
+	
+	#Tell the player this pickup can be equipped
+	player.allow_equip.emit(self)
+
+func _on_pickup_area_area_exited(area: Area2D) -> void:	
+	# Only players should trigger pickup logic
+	if area.owner.get_script().get_global_name() != "Player" or pickup_blocked:
+		return
+	
+	var player: Player = area.owner
+	player_in_range = false
+	
+	# FIXME: This signal is triggered, and the below line produces an error, when equipping happens and the pickup despawns.
+	# It doesnt seem to effect anything, but its red and in big capital letter, so it could be bad later.
+	toggle_light.rpc_id(player.get_multiplayer_authority())
+	
+	#Tell the player that this is no longer available to equip
+	player.allow_equip.emit(null)
 
 func _on_cooldown_timer_timeout() -> void:
-	can_pickup = true
+	pickup_blocked = false
 
+## Despawns 	
 @rpc("any_peer", "call_local", "reliable")
 func server_despawn():
 	if multiplayer.is_server():
-		var callable_pickup_destroy = pickup.queue_free.bind()
-		#get_tree().process_frame.connect()
+		pickup.queue_free()
 
-		#FIXME: Unless this delay is added, the Main trees PickupSpawner may delete a Pickup on the server side, before the player script has a chance
-		# to see and equip it. This means that once colliding with the players hitbox, it will effectively vanish into thin air.
-
-		# The fix for this is probably just signal ordering. Instead of emitting, and then immediately despawning the item. We should emit a signal,
-		# and then somehow await some kind of response from the equip (another signal maybe?) before executing the server_despawn.rpc() call.
-
-		# Manual pickup events will need to implement this signal waiting anyway, so maybe the fix is just to make that happen
-		get_tree().create_timer(0.2).timeout.connect(callable_pickup_destroy, CONNECT_ONE_SHOT)
+## Toggles a pickup light. Should only be called on the client which is interacting it by using the multiplayer authority of the player body
+@rpc("any_peer", "call_local")
+func toggle_light():	
+	if player_in_range:
+		pickup_light.show()
+	else:
+		pickup_light.hide()

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -2,7 +2,15 @@ class_name Player extends CharacterBody2D
 
 signal throw
 signal released
+
+## Emitted by the pickups themselves when pickup zone collision occurs, used to set the available pickup and allow input for equipping
+signal allow_equip
+
+## Used to signal when the weapon should be equipped by the player 
 signal equip
+## Used to make sure the weapon does not despawn to early before being equipped properly
+signal done_equipping 
+
 
 var spawn_position = Vector2(1500, 500)
 
@@ -33,6 +41,8 @@ class PlayerState:
 	}
 	var air_state: AirState # You can never be airborn and grounded at the same time. This structure ensures that.
 	var walled: bool
+	
+	var available_pickup: Pickup
 	var equipped_weapon: Weapon
 
 	func _init() -> void:
@@ -52,7 +62,6 @@ func _ready() -> void:
 func _enter_tree() -> void:
 	set_multiplayer_authority(str(name).to_int())
 	$IDLabelDebug.text = str(name)
-	print("Multiplayer Authority: ", get_multiplayer_authority())
 
 func _process(_delta: float) -> void:
 	pass
@@ -94,8 +103,7 @@ func get_horizontal_movement(delta: float):
 	velocity.x = move_toward(velocity.x, direction * speed, (acceleration if state.is_grounded() else arial_acceleration) * delta)
 
 
-# Input handling:
-#  At the top level [method handle_input] handles all direct input and calls various utility function based on that input
+## Input handling: At the top level [method handle_input] handles all direct input and calls various utility function based on that input
 func handle_input():
 	if Input.is_action_just_pressed("jump"):
 		sprite.play("crouch")
@@ -106,6 +114,11 @@ func handle_input():
 
 	if Input.is_action_pressed("throw"):
 		throw.emit()
+	
+	if Input.is_action_pressed("equip"):
+		if state.available_pickup:
+			equip.emit(state.available_pickup.weapon_scene)
+			
 
 func handle_jump_input(delta):
 	if state.is_grounded():
@@ -130,7 +143,11 @@ func wall_jump():
 func _on_animation_trigger_area_body_entered(_body: Node2D) -> void:
 	sprite.play("default")
 	
+
 # WEAPON EQUIPPING
+func _on_allow_equip(pickup: Pickup = null) -> void:
+	state.available_pickup = pickup
+
 func _on_equip(weapon_scene: PackedScene) -> void:
 	if is_multiplayer_authority():
 		var weapon: Weapon = weapon_scene.instantiate()
@@ -138,9 +155,12 @@ func _on_equip(weapon_scene: PackedScene) -> void:
 		weapon_marker.add_child.call_deferred(weapon)	
 		#weapon.global_transform = weapon_marker.global_transform
 		throw.connect(weapon._on_throw)
+		
+		# Tell the server to despawn the pickup after we have equipped it and forget about it
+		state.available_pickup.server_despawn.rpc_id(1)
+		state.available_pickup = null
 
 func _on_released() -> void:
-
 	if is_multiplayer_authority():
 		weapon_marker.remove_child(state.equipped_weapon)
 		state.equipped_weapon.call_deferred("queue_free")


### PR DESCRIPTION
Adding pickup logic as follows:

- When collision occurs signal that the player can pickup this weapon
- Player signal recieves changes state to allow for input
- Input occurs calls equip on the player and requests despawn of pickup server side. 