### PR TITLE
Player id type fix for proper authority assignment.

### DIFF
--- a/scripts/gamestate.gd
+++ b/scripts/gamestate.gd
@@ -80,12 +80,12 @@ func request_registration(local: bool = false, id = multiplayer.get_remote_sende
 
 
 func register_player(id: int):
-	var player_id = str(id)
+	var player_id = id
 	if player_ids.has(player_id):
 		return
 
 	player_ids.push_front(player_id)
-	win_tally[player_id] = 0
+	win_tally[str(player_id)] = 0
 	sync_player_state.rpc(player_ids, win_tally)
 
 @rpc("call_local", "reliable")
@@ -136,28 +136,29 @@ func start_game(start_source: StartSource):
 	# If they are a local connection from that client but not the primary player, then set the spawned player name to the client ID + 
 	# however many secondary local players we have on that client
 	
-	
 	# TODO: Something about authority assignment is bricked here 
 	player_ids.sort()
+	# TODO: Sometimes this isnt getting sorted. An early return of some kind?
+	print("After sort: ", player_ids)
 	var latest_remote_index = null # Keep track of the most recent primary player, so that we can set secondary local player ids off of that one
 	for i in player_ids.size():
 		var authority
 		var local = false
 		if int(player_ids[i]) == int(player_ids[i-1]) + 1:
 			local = true
-			authority = player_ids[latest_remote_index].to_int()
+			authority = player_ids[latest_remote_index]
 		else:
-			authority = player_ids[i].to_int()
+			authority = player_ids[i]
 			latest_remote_index = i
 		
-		player_spawner.spawn({"id": player_ids[i].to_int(), "position": spawn_positions[i], "authority": authority, "local": local, "local_id": i - latest_remote_index})
+		player_spawner.spawn({"id": player_ids[i], "position": spawn_positions[i], "authority": authority, "local": local, "local_id": i - latest_remote_index})
 		
 
 ## Ends the round for all players. Called by whichever peer is the last to day when player count is tracked to one by their Main client.
 @rpc("any_peer", "call_local")
 func end_round(player: Player):
 	assert(multiplayer.is_server())
-	win_tally[player.name] += 1
+	win_tally[str(player.name)] += 1
 	score_changed.emit()
 	sync_score_tally.rpc(win_tally)
 	load_end_round.rpc(player.name, win_tally[player.name] >= winning_rounds_required)

--- a/scripts/gamestate.gd
+++ b/scripts/gamestate.gd
@@ -116,7 +116,6 @@ enum StartSource {
 	NEXTROUND
 }
 
-# TODO: Need to have a seperate start game / start round
 func start_game(start_source: StartSource):
 	assert(multiplayer.is_server())
 	assert(player_ids.size() <= 4)
@@ -136,10 +135,7 @@ func start_game(start_source: StartSource):
 	# If they are a local connection from that client but not the primary player, then set the spawned player name to the client ID + 
 	# however many secondary local players we have on that client
 	
-	# TODO: Something about authority assignment is bricked here 
 	player_ids.sort()
-	# TODO: Sometimes this isnt getting sorted. An early return of some kind?
-	print("After sort: ", player_ids)
 	var latest_remote_index = null # Keep track of the most recent primary player, so that we can set secondary local player ids off of that one
 	for i in player_ids.size():
 		var authority


### PR DESCRIPTION
Fixes #39 

> Weird one.
Upon registering, players are being assigned to a player_ids array. However they are being assigned as strings, meaning attempting the sort the array to determine proper authority was failing because it was performing the sort as if the values were strings (even though they are integers). The reason this broke sometimes was because the randomly assigned id may have started with the number 1 which in a string sort puts it ahead of 2 regardless of the size of the number based on the digits after it. This reason this was done was because it assists with keeping track of score, since those same IDs are being used in a Dictionary which only works with string type keys. The fix was to keep the player ids as integers in the array so that it could be sorted correctly, and then at the point of adding them to the dictionary that keeps track of score, convert them to strings.